### PR TITLE
fix: Simplify session store and delete logic

### DIFF
--- a/connections.go
+++ b/connections.go
@@ -55,14 +55,5 @@ func (instance *Instance[T]) Get(userId string, sessionId string) (*Session[T], 
 }
 
 func (instance *Instance[T]) GetConnections(userId string) int {
-	sessionList, ok := instance.sessionsCache.sessions.Load(userId)
-	if !ok {
-		return 0
-	}
-	sessions := sessionList.(*SessionsList)
-	sessions.mutex.RLock()
-	sessionIds := sessions.sessions
-	sessions.mutex.RUnlock()
-
-	return len(sessionIds)
+	return len(instance.GetSessions(userId))
 }

--- a/neogate.go
+++ b/neogate.go
@@ -16,14 +16,9 @@ var Log = log.New(log.Writer(), "neogate ", log.Flags())
 type Instance[T any] struct {
 	Config           Config[T]
 	connectionsCache *sync.Map // UserId:sessionId -> *Session
-	sessionsCache    SessionCache
+	sessions         *sync.Map // UserId -> SessionsList
 	adapters         *sync.Map // AdapterId -> *Adapter
 	routes           map[string]func(*Context[T]) Event
-}
-
-type SessionCache struct {
-	mutex    *sync.Mutex
-	sessions *sync.Map // UserId -> SessionsList
 }
 
 type SessionsList struct {
@@ -83,11 +78,8 @@ func Setup[T any](config Config[T]) *Instance[T] {
 		Config:           config,
 		adapters:         &sync.Map{},
 		connectionsCache: &sync.Map{},
-		sessionsCache: SessionCache{
-			sessions: &sync.Map{},
-			mutex:    &sync.Mutex{},
-		},
-		routes: make(map[string]func(*Context[T]) Event),
+		sessions:         &sync.Map{},
+		routes:           make(map[string]func(*Context[T]) Event),
 	}
 	return instance
 }

--- a/send.go
+++ b/send.go
@@ -1,26 +1,16 @@
 package neogate
 
 import (
-	"errors"
-
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/websocket/v2"
 )
 
 // SendEventToUser sends the event to all sessions connected to the userId
 func (instance *Instance[T]) SendEventToUser(userId string, event Event) error {
-
-	sessionList, ok := instance.sessionsCache.sessions.Load(userId)
-	if !ok {
-		return errors.New("no sessions found")
-	}
-	sessions := sessionList.(*SessionsList)
-	sessions.mutex.RLock()
-	sessionIds := sessions.sessions
-	sessions.mutex.RUnlock()
+	sessions := instance.GetSessions(userId)
 
 	adapterIds := []string{}
-	for _, sessionId := range sessionIds {
+	for _, sessionId := range sessions {
 		_, sessionAdapterName := instance.Config.SessionAdapterHandler(userId, sessionId)
 		adapterIds = append(adapterIds, sessionAdapterName)
 	}

--- a/sessions.go
+++ b/sessions.go
@@ -104,7 +104,9 @@ func (instance *Instance[T]) createSession(session *Session[T]) {
 	sessionList.mutex.Lock()
 	defer sessionList.mutex.Unlock()
 
-	sessionList.sessions = append(sessionList.sessions, session.GetSessionId())
+	if loaded {
+		sessionList.sessions = append(sessionList.sessions, session.GetSessionId())
+	}
 	instance.sessions.Store(session.GetUserId(), sessionList) // Store here in case the thing was deleted while the mutex was locked
 }
 


### PR DESCRIPTION
This MR does the following things:
- Simplifies session store and delete logic + gets rid of the global mutex
- Makes sure sessions are properly copied and the cache is only accessed where absolutely needed (to prevent messing up with mutexes)